### PR TITLE
Fix wrong default values and yaml configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,24 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_network` | minimal | Predefined network configuration |
 | `teku_default_ip` | "127.0.0.1" | |
 | `teku_host_ip` | "" | |
-| `teku_p2p_enabled` | False | Enables or disables all P2P communication |
+| `teku_p2p_enabled` | True | Enables or disables all P2P communication |
 | `teku_p2p_interface` | 0.0.0.0 | Specifies the network interface on which the node listens for P2P communication |
 | `teku_p2p_port` | 9000 | Specifies the P2P listening ports (UDP and TCP) |
 | `teku_p2p_advertised_port` | 9000 | The advertised P2P port |
-| `teku_p2p_discovery_enabled` | False | Enables or disables P2P peer discovery |
+| `teku_p2p_discovery_enabled` | True | Enables or disables P2P peer discovery |
 | `teku_interop_genesis_time` | 0 | |
 | `teku_interop_start_state` | "" | |
 | `teku_interop_owned_validator_start_index` | 0 | |
 | `teku_interop_owned_validator_count` | 64 | |
 | `teku_interop_number_of_validators` | 64 | |
-| `teku_interop_enabled` | True | |
+| `teku_interop_enabled` | False | |
 | `teku_validators_key_file` | "" | Path to the YAML formatted file to load unencrypted validator keys from |
 | `teku_deposit_mode` | normal | |
 | `teku_deposit_input_file` | "" | |
 | `teku_deposit_number_validators` | 64 | |
 | `teku_deposit_contract_address` | 0x | Eth1 address of deposit contract |
 | `teku_deposit_eth1_endpoint` | "http://0.0.0.0:8545" | JSON-RPC URL of Eth1 node |
-| `teku_metrics_enabled` | False | Set to true to enable the metrics exporter |
+| `teku_metrics_enabled` | True | Set to true to enable the metrics exporter |
 | `teku_metrics_interface` | 0.0.0.0 | |
 | `teku_metrics_port` | 8008 | |
 | `teku_metrics_categories` | ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"] | Categories for which to track metrics |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,11 +57,11 @@ teku_deposit_eth1_endpoint: "http://0.0.0.0:8545"
 
 teku_metrics_enabled: "True"
 teku_metrics_interface: 0.0.0.0
-teku_metrics_host_whitelist: ["*"]
+teku_metrics_host_allowlist: ["*"]
 teku_metrics_port: 8008
-teku_metrics_categories: []
+teku_metrics_categories: ["BEACON","LIBP2P","NETWORK","EVENTBUS","JVM","PROCESS","STORAGE","VALIDATOR"]
 
-teku_data_path: "."
+teku_data_path: "/data"
 teku_data_storage_mode: "prune"
 
 teku_beacon_rest_api_port: 5051

--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -60,7 +60,7 @@ metrics-interface : "{{teku_metrics_interface}}"
 {% if teku_metrics_categories != [] %}
 metrics-categories: [{{teku_metrics_categories|map('to_json')|join(',')}}]
 {% endif %}
-metrics-host-whitelist: [{{teku_metrics_host_whitelist|map('to_json')|join(',')}}]
+metrics-host-allowlist: [{{teku_metrics_host_allowlist|map('to_json')|join(',')}}]
 {% endif %}
 
 # database


### PR DESCRIPTION
- Fixes wrong default values
- Changes YAML configuration name `metrics-host-whitelist` to `metrics-host-allowlist` (which hindered Teku from starting due to unknown config option name)
- Changes data path to the value that was told on default values: /data (this is preferable since our default AWS nodes have bigger disk space under their /data directory)

