### PR TITLE
Set advertised IP in config

### DIFF
--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -13,7 +13,7 @@ p2p-enabled: {{teku_p2p_enabled}}
 p2p-interface: "{{teku_p2p_interface}}"
 p2p-port: {{teku_p2p_port}}
 {% if teku_host_ip != "" %}
-p2p-advertised-ip: {{ teku_host_ip }}
+p2p-advertised-ip: "{{ teku_host_ip }}"
 {% endif %}
 p2p-advertised-port: {{teku_p2p_advertised_port}}
 p2p-discovery-enabled: {{teku_p2p_discovery_enabled}}

--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -12,6 +12,9 @@ initial-state: "{{teku_initial_state}}"
 p2p-enabled: {{teku_p2p_enabled}}
 p2p-interface: "{{teku_p2p_interface}}"
 p2p-port: {{teku_p2p_port}}
+{% if teku_host_ip != "" %}
+p2p-advertised-ip: {{ teku_host_ip }}
+{% endif %}
 p2p-advertised-port: {{teku_p2p_advertised_port}}
 p2p-discovery-enabled: {{teku_p2p_discovery_enabled}}
 {% if teku_node_private_key_file != "" %}


### PR DESCRIPTION
If `teku_host_ip` is set it should be set as the advertised IP in the Teku config.