### PR TITLE
Support for standalone mode for Teku

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_deposit_eth1_endpoint` | "http://0.0.0.0:8545" | JSON-RPC URL of Eth1 node |
 | `teku_metrics_enabled` | True | Set to true to enable the metrics exporter |
 | `teku_metrics_interface` | 0.0.0.0 | |
-| `teku_metrics_port` | 8008 | |
+| `teku_metrics_port` | 8008 | Metric port when deployed as monolith |
+| `teku_beacon_metrics_port` | 8008 | Beacon service metric port when deployed as standalone |
+| `teku_validator_metrics_port` | 8009 | Validator service metric port when deployed as standalone |
 | `teku_metrics_categories` | ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"] | Categories for which to track metrics |
-| `teku_data_path` | /data | |
+| `teku_data_path` | /data | Use same folder for both validator and beaon service in standalone mode |
 | `teku_data_storage_mode` | prune | Set the strategy for handling historical chain data |
 | `teku_beacon_rest_api_port` | 5051 | |
 | `teku_beacon_rest_api_docs_enabled` | False | |
@@ -78,6 +80,14 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_beacon_rest_api_host_allowlist` | ["*"] | Host allowlist for for the REST API service |
 | `teku_cmdline_args` | [] | |
 | `teku_env_opts` | [] | |
+| `teku_standalone_validator` | False | Run validator in standalone mode |
+
+### Standalone Mode
+
+It is possible to configure Teku to run in either monolith mode (both beacon and validator run in same process) or standalone mode(beacon and validator run in its own process).
+Standalone mode runs beacon service its own process and validator service in its own process. Systemd service name `teku` is used for beacon service
+and `teku-validator` is used for validator service when run in standalone mode. Ansible role defaults to run Teku in monolith mode and behaviour can be controlled with the
+variable `teku_standalone_validator=False/True`.
 
 ### Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,3 +78,33 @@ teku_validator_key_password_files: []
 
 # internal state to maintain idempotency
 teku_state_updates: []
+teku_state_updates_validator: []
+teku_state_updates_beacon: []
+
+# Defaults for monolith service for backward compatibility
+teku_sub_command: ''
+teku_log_file: "{{ teku_log_dir }}/teku.log"
+teku_config_file: "{{ teku_config_dir }}/teku.yml"
+
+# determine whether to run as standalone validator client. Default is not to run standalone validator
+teku_standalone_validator: False
+
+# Configuration for monolith teku client
+teku_monolith_service_name: 'teku'
+teku_monolith_service_file: "{{ teku_systemd_dir }}/teku.service"
+teku_monolith_log_file: "{{ teku_log_dir }}/teku.log"
+teku_monolith_config_file: "{{ teku_config_dir }}/teku.yml"
+
+# Configuration for standalone validator client
+teku_validator_service_name: 'teku-validator'
+teku_validator_service_file: "{{ teku_systemd_dir }}/teku-validator.service"
+teku_validator_log_file: "{{ teku_log_dir }}/teku-validator.log"
+teku_validator_config_file: "{{ teku_config_dir }}/teku-validator.yml"
+teku_validator_metrics_port: '8009'
+
+# Configuration for standalone beacon client
+teku_beacon_service_name: 'teku'
+teku_beacon_service_file: "{{ teku_systemd_dir }}/teku.service"
+teku_beacon_log_file: "{{ teku_log_dir }}/teku.log"
+teku_beacon_config_file: "{{ teku_config_dir }}/teku.yml"
+teku_beacon_metrics_port: '8008'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,19 +8,55 @@
     recurse: yes
   become: true
 
-- name: Generate config file
+- name: Generate config file - monolith
   template:
     src: "{{ teku_config_template }}"
-    dest: "{{ teku_config_dir }}/teku.yml"
+    dest: "{{ teku_monolith_config_file }}"
     owner: "{{ teku_user }}"
     group: "{{ teku_group }}"
   become: true
   register: config_toml
+  when: "not teku_standalone_validator"
 
 - name: Set updated optionally to trigger a systemd restart at the end
   set_fact:
     teku_state_updates: "{{ teku_state_updates + ['teku.config_toml'] }}"
   when: config_toml is changed
+
+- name: Generate config file - standalone
+  block:
+    - name: Configuration file - beacon
+      template:
+        src: "{{ teku_config_template }}"
+        dest: "{{ teku_beacon_config_file }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+      become: true
+      register: config_toml_beacon
+      vars:
+        teku_metrics_port: "{{ teku_beacon_metrics_port }}"
+
+    - name: Set updated optionally to trigger a systemd restart at the end - beacon
+      set_fact:
+        teku_state_updates_beacon: "{{ teku_state_updates_beacon + ['teku.config_toml'] }}"
+      when: config_toml_beacon is changed
+
+    - name: Configuration file - validator
+      template:
+        src: "{{ teku_config_template }}"
+        dest: "{{ teku_validator_config_file }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+      become: true
+      register: config_toml_validator
+      vars:
+        teku_metrics_port: "{{ teku_validator_metrics_port }}"
+
+    - name: Set updated optionally to trigger a systemd restart at the end - validator
+      set_fact:
+        teku_state_updates_validator: "{{ teku_state_updates_validator + ['teku.config_toml'] }}"
+      when: config_toml_validator is changed
+  when: "teku_standalone_validator"
 
 # TODO: add this in when Teku supports the data dir option - see the pre_install file for now
 #- name: Create data directory

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,35 +1,163 @@
 ---
-- name: Create Teku systemd service
-  template:
-    src: "{{ teku_systemd_template }}"
-    dest: "{{ teku_systemd_dir }}/teku.service"
-    owner: "root"
-    group: "root"
-  become: true
-  when: ( teku_managed_service ) and
-    ( ansible_os_family != "Darwin" )
-  register: systemd_file
 
-- name: Set updated optionally to trigger a systemd restart at the end
-  set_fact:
-    teku_state_updates: "{{ teku_state_updates + ['teku.systemd_file'] }}"
-  when: systemd_file is changed
+- name: Check standalone validater systemd file exist
+  stat:
+    path: "{{ teku_validator_service_file }}"
+  register: teku_standalone_validator_file_stat
 
-- name: Reload systemd to reread configs
-  systemd:
-    daemon_reload: yes
-  become: true
-  when: systemd_file is changed
+# Configure and start monolith service
+- name: Configure monolith
+  block:
 
-- name: Enable and start Teku service
-  systemd:
-    name: teku
-    state: "{{ teku_systemd_state }}"
-    enabled: true
-  become: true
-  when: ( teku_state_updates|length > 0 ) and
-    ( teku_managed_service ) and
-    ( ansible_os_family != "Darwin" )
+    # Stop standalone validator and beacon before configuring monolith
+    # Running two validators result in penalty
+    - name: Stop standalone validator service
+      systemd:
+        name: "{{ teku_validator_service_name }}"
+        state: stopped
+        enabled: no
+      become: true
+      when: "teku_standalone_validator_file_stat.stat.exists"
+
+    - name: Stop standalone beacon service
+      systemd:
+        name: "{{ teku_beacon_service_name }}"
+        state: stopped
+      become: true
+      when: "teku_standalone_validator_file_stat.stat.exists"
+      register: stop_standalone_beacon
+
+    - name: Set updated optionally to trigger a systemd restart at the end
+      set_fact:
+        teku_state_updates: "{{ teku_state_updates + ['teku.service_stopped'] }}"
+      when: stop_standalone_beacon is changed
+
+    - name: Remove standalone validator systemd file
+      file:
+        path: "{{ teku_validator_service_file }}"
+        state: absent
+      become: true
+
+    - name: Create Teku monolith systemd service
+      template:
+        src: "{{ teku_systemd_template }}"
+        dest: "{{ teku_monolith_service_file }}"
+        owner: "root"
+        group: "root"
+      become: true
+      when:
+        - teku_managed_service
+      register: systemd_file
+
+    - name: Set updated optionally to trigger a systemd restart at the end
+      set_fact:
+        teku_state_updates: "{{ teku_state_updates + ['teku.systemd_file'] }}"
+      when: systemd_file is changed
+
+    - name: Reload systemd to reread configs
+      systemd:
+        daemon_reload: yes
+      become: true
+      when: systemd_file is changed
+
+    - name: Enable and start Teku service
+      systemd:
+        name: "{{ teku_monolith_service_name }}"
+        state: "{{ teku_systemd_state }}"
+        enabled: true
+      become: true
+      when:
+        - teku_state_updates|length > 0
+        - teku_managed_service
+
+  when:
+    - "ansible_os_family != 'Darwin'"
+    - "not teku_standalone_validator"
+
+
+# Configure and start standalone services
+- name: Configure standalone validator
+  block:
+
+    - name: Stop monolith service
+      systemd:
+        name: "{{ teku_monolith_service_name }}"
+        state: stopped
+      become: true
+      when: "not teku_standalone_validator_file_stat.stat.exists"
+
+    - name: Create Teku beacon systemd service
+      template:
+        src: "{{ teku_systemd_template }}"
+        dest: "{{ teku_beacon_service_file }}"
+        owner: "root"
+        group: "root"
+      become: true
+      when:
+        - teku_managed_service
+      register: systemd_file_beacon
+      vars:
+        teku_cmdline_args:
+          - '--Xremote-validator-api-enabled'
+        teku_validator_key_files: []
+        teku_log_file: "{{ teku_beacon_log_file }}"
+        teku_config_file: "{{ teku_beacon_config_file }}"
+
+    - name: Set updated optionally to trigger a systemd beacon restart at the end
+      set_fact:
+        teku_state_updates_beacon: "{{ teku_state_updates_beacon + ['teku.systemd'] }}"
+      when: systemd_file_beacon is changed
+
+    - name: Create Teku validator systemd service
+      template:
+        src: "{{ teku_systemd_template }}"
+        dest: "{{ teku_validator_service_file }}"
+        owner: "root"
+        group: "root"
+      become: true
+      when:
+        - teku_managed_service
+      register: systemd_file_validator
+      vars:
+        teku_sub_command: 'validator-client'
+        teku_log_file: "{{ teku_validator_log_file }}"
+        teku_config_file: "{{ teku_validator_config_file }}"
+
+    - name: Set updated optionally to trigger a systemd validator restart at the end
+      set_fact:
+        teku_state_updates_validator: "{{ teku_state_updates_validator + ['teku.systemd'] }}"
+      when: systemd_file_validator is changed
+
+    - name: Reload systemd to reread configs
+      systemd:
+        daemon_reload: yes
+      become: true
+      when: "systemd_file_beacon is changed or systemd_file_validator is changed"
+
+    - name: Enable and start Teku service - beacon
+      systemd:
+        name: "{{ teku_beacon_service_name }}"
+        state: "{{ teku_systemd_state }}"
+        enabled: true
+      become: true
+      when:
+        - teku_state_updates_beacon|length > 0
+        - teku_managed_service
+
+    - name: Enable and start Teku service - validator
+      systemd:
+        name: "{{ teku_validator_service_name }}"
+        state: "{{ teku_systemd_state }}"
+        enabled: true
+      become: true
+      when:
+        - teku_state_updates_validator|length > 0
+        - teku_managed_service
+
+  when:
+    - "ansible_os_family != 'Darwin'"
+    - teku_standalone_validator
+
 
 # Darwin only
 - name: Create Launchd service plist for Darwin

--- a/templates/teku.service.j2
+++ b/templates/teku.service.j2
@@ -12,9 +12,9 @@ Environment=LOG4J_CONFIGURATION_FILE={{ teku_log4j_config_file }}
 {% endif %}
 Type=simple
 {% if teku_cmdline_args %}
-ExecStart=/bin/sh -c "{{ teku_current_dir }}/bin/teku -c {{ teku_config_dir }}/teku.yml {{teku_cmdline_args|map('to_json')|join(' ')|regex_replace('"','')}} >> {{ teku_log_dir }}/teku.log 2>&1"
+ExecStart=/bin/sh -c "{{ teku_current_dir }}/bin/teku -c {{ teku_config_file }} {{ teku_sub_command }} {{teku_cmdline_args|map('to_json')|join(' ')|regex_replace('"','')}} >> {{ teku_log_file }} 2>&1"
 {% else %}
-ExecStart=/bin/sh -c "{{ teku_current_dir }}/bin/teku -c {{ teku_config_dir }}/teku.yml >> {{ teku_log_dir }}/teku.log 2>&1"
+ExecStart=/bin/sh -c "{{ teku_current_dir }}/bin/teku -c {{ teku_config_file }} {{ teku_sub_command }} >> {{ teku_log_file }} 2>&1"
 {% endif %}
 SuccessExitStatus=143
 Restart=on-failure


### PR DESCRIPTION
- Ansible role support installing Teku either in monolith (beacon and validator services on same process) or standalone (beacon and validator services on its own process)
- Deployment support migrating from monolith to standalone and vice versa
- Separate configuration files are maintained in standalone mode