### PR TITLE
Fixed deploying teku in standalone mode in initial installation

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -79,12 +79,19 @@
 - name: Configure standalone validator
   block:
 
+    - name: Check teku systemd file exist
+      stat:
+        path: "{{ teku_monolith_service_file }}"
+      register: teku_monolith_file_stat
+
     - name: Stop monolith service
       systemd:
         name: "{{ teku_monolith_service_name }}"
         state: stopped
       become: true
-      when: "not teku_standalone_validator_file_stat.stat.exists"
+      when:
+        - "not teku_standalone_validator_file_stat.stat.exists"
+        - "teku_monolith_file_stat.stat.exists"
 
     - name: Create Teku beacon systemd service
       template:


### PR DESCRIPTION
If the Teku is installed as standalone for the very first time there is no teku systemd file available and task fails trying to stop the service. Added check to verify whether teku systemd file exist before the service is stopped