### PR TITLE
Fix validator key configuration

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,14 +8,22 @@
     recurse: yes
   become: true
 
-- name: Generate config file - monolith
-  template:
-    src: "{{ teku_config_template }}"
-    dest: "{{ teku_monolith_config_file }}"
-    owner: "{{ teku_user }}"
-    group: "{{ teku_group }}"
-  become: true
-  register: config_toml
+- name: Configuration file - monolith
+  block:
+  - name: Remove stanalone validator config file
+    file:
+      path: "{{ teku_validator_config_file }}"
+      state: absent
+    become: true
+
+  - name: Generate config file - monolith
+    template:
+      src: "{{ teku_config_template }}"
+      dest: "{{ teku_monolith_config_file }}"
+      owner: "{{ teku_user }}"
+      group: "{{ teku_group }}"
+    become: true
+    register: config_toml
   when: "not teku_standalone_validator"
 
 - name: Set updated optionally to trigger a systemd restart at the end
@@ -25,6 +33,7 @@
 
 - name: Generate config file - standalone
   block:
+    # Set empty list for key and password files to remove the configuration for beacon in standalone mode
     - name: Configuration file - beacon
       template:
         src: "{{ teku_config_template }}"
@@ -35,6 +44,8 @@
       register: config_toml_beacon
       vars:
         teku_metrics_port: "{{ teku_beacon_metrics_port }}"
+        teku_validator_key_files: []
+        teku_validator_key_password_files: []
 
     - name: Set updated optionally to trigger a systemd restart at the end - beacon
       set_fact:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -104,9 +104,6 @@
         - teku_managed_service
       register: systemd_file_beacon
       vars:
-        teku_cmdline_args:
-          - '--Xremote-validator-api-enabled'
-        teku_validator_key_files: []
         teku_log_file: "{{ teku_beacon_log_file }}"
         teku_config_file: "{{ teku_beacon_config_file }}"
 


### PR DESCRIPTION
- Validator keys only be configured in Teku validator configuration file in standalone mode. Set empty key configuration on template task to prevent key configuration on the Teku becon configuration file when run in standalone mode
- Removed validator configuration file if exist when switch back to monolith mode
- Removed unused command line option --Xremote-validator-api-enabled