### PR TITLE
Remove invalid configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_install_dir` | /opt/teku | Path to install to  |
 | `teku_config_dir` | /etc/teku | Path for default configuration |
 | `teku_data_dir` | /opt/teku/data | Path for data directory|
-| `teku_log_dir` | /var/log/teku | Path for logs |
+| `teku_log_dir` | /var/log/teku | Path for logs directory |
+| `teku_log_filename` | {{ `teku_log_dir` }}/teku.log | Path containing the location (relative or absolute) and the log filename | 
 | `teku_profile_file` | /etc/profile.d/teku-path.sh | Path to allow loading teku into the system PATH |
 | `teku_managed_service` | true | Enables a systemd service (or launchd if on Darwin) |
 | `teku_launchd_dir` | /Library/LaunchAgents | The default launchd directory  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ besu_profile_file: "/etc/profile.d/teku-path.sh"
 teku_log_level: INFO
 teku_log_color_enabled: False
 teku_log_destination: 'DEFAULT_BOTH'
-teku_log_filename: 'teku.log'
+teku_log_filename: "{{ teku_log_dir }}/teku.log"
 teku_log_filename_pattern: 'teku_%d{yyyy-MM-dd}.log'
 teku_log_include_events_enabled: False
 

--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -66,7 +66,6 @@ log-include-events-enabled: {{ teku_log_include_events_enabled }}
 log-destination: "{{ teku_log_destination }}"
 log-file: "{{ teku_log_filename }}"
 log-file-name-pattern: "{{ teku_log_filename_pattern }}"
-log-path: "{{teku_log_dir}}"
 logging: "{{ teku_log_level }}"
 {% if teku_log_validator_duties is defined and teku_log_validator_duties != '' %}
 log-include-validator-duties-enabled: {{ teku_log_validator_duties }}


### PR DESCRIPTION
Removed the configuration parameter `log-path` from the configuration file as it is not used any more.
Made log file prefixed with the log directory path, otherwise it will use relative path which user may be confused.