### PR TITLE
Ability to configure OPTS for teku beacon and validator independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_beacon_rest_api_host_allowlist` | ["*"] | Host allowlist for for the REST API service |
 | `teku_cmdline_args` | [] | |
 | `teku_env_opts` | [] | |
+| `teku_env_opts_beacon` | `teku_env_opts` | Only applicable in standalone mode. Allows setting beacon specific values |
+| `teku_env_opts_validator` | `teku_env_opts` | Only applicable in standalone mode. Allows setting validator specific values |
 | `teku_standalone_validator` | False | Run validator in standalone mode |
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,10 @@ teku_beacon_rest_api_host_allowlist: ["*"]
 
 teku_cmdline_args: ""
 teku_env_opts: ""
+# Using an internal variable for setting the configuration. This avoids circular reference.
+teku_env_opts_internal: "{{ teku_env_opts }}"
+teku_env_opts_beacon: "{{ teku_env_opts }}"
+teku_env_opts_validator: "{{ teku_env_opts }}"
 
 teku_validator_key_files: []
 teku_validator_key_password_files: []

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -116,6 +116,7 @@
       vars:
         teku_log_file: "{{ teku_beacon_log_file }}"
         teku_config_file: "{{ teku_beacon_config_file }}"
+        teku_env_opts_internal: "{{ teku_env_opts_beacon }}"
 
     - name: Set updated optionally to trigger a systemd beacon restart at the end
       set_fact:
@@ -136,6 +137,7 @@
         teku_sub_command: 'validator-client'
         teku_log_file: "{{ teku_validator_log_file }}"
         teku_config_file: "{{ teku_validator_config_file }}"
+        teku_env_opts_internal: "{{ teku_env_opts_validator }}"
 
     - name: Set updated optionally to trigger a systemd validator restart at the end
       set_fact:

--- a/templates/teku.service.j2
+++ b/templates/teku.service.j2
@@ -6,7 +6,7 @@ After=syslog.target network.target
 User={{ teku_user }}
 Group={{ teku_group }}
 Environment=HOME=/home/{{ teku_user }}
-Environment='TEKU_OPTS={{teku_env_opts|map('to_json')|join(' ')}}'
+Environment='TEKU_OPTS={{ teku_env_opts_internal|map('to_json')|join(' ') }}'
 {% if teku_log4j_config_file %}
 Environment=LOG4J_CONFIGURATION_FILE={{ teku_log4j_config_file }}
 {% endif %}


### PR DESCRIPTION
TEKU OPTS values could be defined using single parameter and this same value has been used when configuring both beacon and validator. This change allows configuring different OPT values for beacon and validator when run in standalone mode