### PR TITLE
Use new artifacts.consensys.net download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_version` | ___unset___ |  __REQUIRED__ Version of teku to install and run. All available versions are listed on our teku [releases](https://github.com/PegaSysEng/teku/releases) page |
 | `teku_user` | teku | teku user |
 | `teku_group` | teku | teku group |
-| `teku_download_url` | https://bintray.com/consensys/pegasys-repo/download_file?file_path=teku-{{ teku_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve teku from a custom location such as an internal repository. |
+| `teku_download_url` | https://artifacts.consensys.net/public/teku/raw/names/teku.tar.gz/versions/{{ teku_version }}/teku-{{ teku_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve teku from a custom location such as an internal repository. |
 | `teku_install_dir` | /opt/teku | Path to install to  |
 | `teku_config_dir` | /etc/teku | Path for default configuration |
 | `teku_data_dir` | /opt/teku/data | Path for data directory|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ teku_user: teku
 teku_group: "{{ teku_user }}"
 
 # Version to install
-teku_download_url: "https://bintray.com/consensys/pegasys-repo/download_file?file_path=teku-{{ teku_version }}.tar.gz"
+teku_download_url: "https://artifacts.consensys.net/public/teku/raw/names/teku.tar.gz/versions/{{ teku_version }}/teku-{{ teku_version }}.tar.gz"
 
 # Directory paths
 teku_base_dir: "/opt/teku"


### PR DESCRIPTION
Update the download URL template to use the Cloudsmith url instead of bintray.