### PR TITLE
Default to no eth1-endpoint instead of an invalid one

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `teku_deposit_input_file` | "" | |
 | `teku_deposit_number_validators` | 64 | |
 | `teku_deposit_contract_address` | 0x | Eth1 address of deposit contract |
-| `teku_deposit_eth1_endpoint` | "http://0.0.0.0:8545" | JSON-RPC URL of Eth1 node |
+| `teku_deposit_eth1_endpoint` | "" | JSON-RPC URL of Eth1 node |
 | `teku_metrics_enabled` | True | Set to true to enable the metrics exporter |
 | `teku_metrics_interface` | 0.0.0.0 | |
 | `teku_metrics_port` | 8008 | Metric port when deployed as monolith |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ teku_deposit_mode: "normal"
 teku_deposit_input_file: "" #"validator_test_data.json"
 teku_deposit_number_validators: 64
 teku_deposit_contract_address: "0x"
-teku_deposit_eth1_endpoint: "http://0.0.0.0:8545"
+teku_deposit_eth1_endpoint: ""
 
 teku_metrics_enabled: "True"
 teku_metrics_interface: 0.0.0.0

--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -54,7 +54,9 @@ validators-key-file: "{{teku_validators_key_file}}"
 {% if teku_deposit_contract_address != "0x" %}
 eth1-deposit-contract-address: "{{teku_deposit_contract_address}}"
 {% endif %}
+{% if teku_deposit_eth1_endpoint != "" %}
 eth1-endpoint: "{{teku_deposit_eth1_endpoint}}"
+{% endif %}
 
 # output
 #Xtransaction-record-directory: "/tmp/teku"


### PR DESCRIPTION
Default to not setting the `eth1-endpoint` instead of to `0.0.0.0` which won't be available and cause a lot of errors in logs.