### PR TITLE
Add merge related options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,85 +28,86 @@ Ansible role that will install, configure and runs [Teku](https://github.com/Peg
 
 All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file. By and large these variables are configuration options. Please refer to the teku [docs](https://docs.teku.consensys.net/en/latest) for more information
 
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `teku_version` | ___unset___ |  __REQUIRED__ Version of teku to install and run. All available versions are listed on our teku [releases](https://github.com/PegaSysEng/teku/releases) page |
-| `teku_user` | teku | teku user |
-| `teku_group` | teku | teku group |
-| `teku_download_url` | https://artifacts.consensys.net/public/teku/raw/names/teku.tar.gz/versions/{{ teku_version }}/teku-{{ teku_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve teku from a custom location such as an internal repository. |
-| `teku_install_dir` | /opt/teku | Path to install to  |
-| `teku_config_dir` | /etc/teku | Path for default configuration |
-| `teku_data_dir` | /opt/teku/data | Path for data directory|
-| `teku_log_dir` | /var/log/teku | Path for logs directory |
-| `teku_log_filename` | {{ `teku_log_dir` }}/teku.log | Path containing the location (relative or absolute) and the log filename | 
-| `teku_profile_file` | /etc/profile.d/teku-path.sh | Path to allow loading teku into the system PATH |
-| `teku_managed_service` | true | Enables a systemd service (or launchd if on Darwin) |
-| `teku_launchd_dir` | /Library/LaunchAgents | The default launchd directory  |
-| `teku_systemd_dir` | /etc/systemd/system/ | The default systemd directory |
-| `teku_systemd_state` | restarted | The default option for the systemd service state |
-| `teku_output_transition_dir` | /tmp/teku | |
-| `teku_node_private_key_file` | "" | |
-| `teku_network` | minimal | Predefined network configuration |
-| `teku_default_ip` | "127.0.0.1" | |
-| `teku_host_ip` | "" | |
-| `teku_p2p_enabled` | True | Enables or disables all P2P communication |
-| `teku_p2p_interface` | 0.0.0.0 | Specifies the network interface on which the node listens for P2P communication |
-| `teku_p2p_port` | 9000 | Specifies the P2P listening ports (UDP and TCP) |
-| `teku_p2p_advertised_port` | 9000 | The advertised P2P port |
-| `teku_p2p_discovery_enabled` | True | Enables or disables P2P peer discovery |
-| `teku_interop_genesis_time` | 0 | |
-| `teku_interop_start_state` | "" | |
-| `teku_interop_owned_validator_start_index` | 0 | |
-| `teku_interop_owned_validator_count` | 64 | |
-| `teku_interop_number_of_validators` | 64 | |
-| `teku_interop_enabled` | False | |
-| `teku_validators_key_file` | "" | Path to the YAML formatted file to load unencrypted validator keys from |
-| `teku_deposit_mode` | normal | |
-| `teku_deposit_input_file` | "" | |
-| `teku_deposit_number_validators` | 64 | |
-| `teku_deposit_contract_address` | 0x | Eth1 address of deposit contract |
-| `teku_deposit_eth1_endpoint` | "" | JSON-RPC URL of Eth1 node |
-| `teku_metrics_enabled` | True | Set to true to enable the metrics exporter |
-| `teku_metrics_interface` | 0.0.0.0 | |
-| `teku_metrics_port` | 8008 | Metric port when deployed as monolith |
-| `teku_beacon_metrics_port` | 8008 | Beacon service metric port when deployed as standalone |
-| `teku_validator_metrics_port` | 8009 | Validator service metric port when deployed as standalone |
-| `teku_metrics_categories` | [] (All categories enabled) | Categories for which to track metrics |
-| `teku_data_path` | /data | Use same folder for both validator and beaon service in standalone mode |
-| `teku_data_storage_mode` | prune | Set the strategy for handling historical chain data |
-| `teku_beacon_rest_api_port` | 5051 | |
-| `teku_beacon_rest_api_docs_enabled` | False | |
-| `teku_beacon_rest_api_enabled` | True | Enable the REST API service |
-| `teku_beacon_rest_api_interface` | 127.0.0.1 | Interface for the REST API service |
-| `teku_beacon_rest_api_host_allowlist` | ["*"] | Host allowlist for for the REST API service |
-| `teku_cmdline_args` | [] | |
-| `teku_env_opts` | [] | |
-| `teku_env_opts_beacon` | `teku_env_opts` | Only applicable in standalone mode. Allows setting beacon specific values |
-| `teku_env_opts_validator` | `teku_env_opts` | Only applicable in standalone mode. Allows setting validator specific values |
-| `teku_standalone_validator` | False | Run validator in standalone mode |
+| Name                                        | Default Value                                                                                                                | Description                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `teku_version`                              | ___unset___                                                                                                                  | __REQUIRED__ Version of teku to install and run. All available versions are listed on our teku [releases](https://github.com/PegaSysEng/teku/releases) page |
+| `teku_user`                                 | teku                                                                                                                         | teku user                                                                                                                                                   |
+| `teku_group`                                | teku                                                                                                                         | teku group                                                                                                                                                  |
+| `teku_download_url`                         | https://artifacts.consensys.net/public/teku/raw/names/teku.tar.gz/versions/{{ teku_version }}/teku-{{ teku_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve teku from a custom location such as an internal repository.                         |
+| `teku_install_dir`                          | /opt/teku                                                                                                                    | Path to install to                                                                                                                                          |
+| `teku_config_dir`                           | /etc/teku                                                                                                                    | Path for default configuration                                                                                                                              |
+| `teku_data_dir`                             | /opt/teku/data                                                                                                               | Path for data directory                                                                                                                                     |
+| `teku_log_dir`                              | /var/log/teku                                                                                                                | Path for logs directory                                                                                                                                     |
+| `teku_log_filename`                         | {{ `teku_log_dir` }}/teku.log                                                                                                | Path containing the location (relative or absolute) and the log filename                                                                                    | 
+| `teku_profile_file`                         | /etc/profile.d/teku-path.sh                                                                                                  | Path to allow loading teku into the system PATH                                                                                                             |
+| `teku_managed_service`                      | true                                                                                                                         | Enables a systemd service (or launchd if on Darwin)                                                                                                         |
+| `teku_launchd_dir`                          | /Library/LaunchAgents                                                                                                        | The default launchd directory                                                                                                                               |
+| `teku_systemd_dir`                          | /etc/systemd/system/                                                                                                         | The default systemd directory                                                                                                                               |
+| `teku_systemd_state`                        | restarted                                                                                                                    | The default option for the systemd service state                                                                                                            |
+| `teku_output_transition_dir`                | /tmp/teku                                                                                                                    |                                                                                                                                                             |
+| `teku_node_private_key_file`                | ""                                                                                                                           |                                                                                                                                                             |
+| `teku_network`                              | minimal                                                                                                                      | Predefined network configuration                                                                                                                            |
+| `teku_default_ip`                           | "127.0.0.1"                                                                                                                  |                                                                                                                                                             |
+| `teku_host_ip`                              | ""                                                                                                                           |                                                                                                                                                             |
+| `teku_p2p_enabled`                          | True                                                                                                                         | Enables or disables all P2P communication                                                                                                                   |
+| `teku_p2p_interface`                        | 0.0.0.0                                                                                                                      | Specifies the network interface on which the node listens for P2P communication                                                                             |
+| `teku_p2p_port`                             | 9000                                                                                                                         | Specifies the P2P listening ports (UDP and TCP)                                                                                                             |
+| `teku_p2p_advertised_port`                  | 9000                                                                                                                         | The advertised P2P port                                                                                                                                     |
+| `teku_p2p_discovery_enabled`                | True                                                                                                                         | Enables or disables P2P peer discovery                                                                                                                      |
+| `teku_interop_genesis_time`                 | 0                                                                                                                            |                                                                                                                                                             |
+| `teku_interop_start_state`                  | ""                                                                                                                           |                                                                                                                                                             |
+| `teku_interop_owned_validator_start_index`  | 0                                                                                                                            |                                                                                                                                                             |
+| `teku_interop_owned_validator_count`        | 64                                                                                                                           |                                                                                                                                                             |
+| `teku_interop_number_of_validators`         | 64                                                                                                                           |                                                                                                                                                             |
+| `teku_interop_enabled`                      | False                                                                                                                        |                                                                                                                                                             |
+| `teku_validators_key_file`                  | ""                                                                                                                           | Path to the YAML formatted file to load unencrypted validator keys from                                                                                     |
+| `teku_deposit_mode`                         | normal                                                                                                                       |                                                                                                                                                             |
+| `teku_deposit_input_file`                   | ""                                                                                                                           |                                                                                                                                                             |
+| `teku_deposit_number_validators`            | 64                                                                                                                           |                                                                                                                                                             |
+| `teku_deposit_contract_address`             | 0x                                                                                                                           | Eth1 address of deposit contract                                                                                                                            |
+| `teku_deposit_eth1_endpoint`                | ""                                                                                                                           | JSON-RPC URL of Eth1 node                                                                                                                                   |
+| `teku_metrics_enabled`                      | True                                                                                                                         | Set to true to enable the metrics exporter                                                                                                                  |
+| `teku_metrics_interface`                    | 0.0.0.0                                                                                                                      |                                                                                                                                                             |
+| `teku_metrics_port`                         | 8008                                                                                                                         | Metric port when deployed as monolith                                                                                                                       |
+| `teku_beacon_metrics_port`                  | 8008                                                                                                                         | Beacon service metric port when deployed as standalone                                                                                                      |
+| `teku_validator_metrics_port`               | 8009                                                                                                                         | Validator service metric port when deployed as standalone                                                                                                   |
+| `teku_metrics_categories`                   | [] (All categories enabled)                                                                                                  | Categories for which to track metrics                                                                                                                       |
+| `teku_data_path`                            | /data                                                                                                                        | Use same folder for both validator and beaon service in standalone mode                                                                                     |
+| `teku_data_storage_mode`                    | prune                                                                                                                        | Set the strategy for handling historical chain data                                                                                                         |
+| `teku_beacon_rest_api_port`                 | 5051                                                                                                                         |                                                                                                                                                             |
+| `teku_beacon_rest_api_docs_enabled`         | False                                                                                                                        |                                                                                                                                                             |
+| `teku_beacon_rest_api_enabled`              | True                                                                                                                         | Enable the REST API service                                                                                                                                 |
+| `teku_beacon_rest_api_interface`            | 127.0.0.1                                                                                                                    | Interface for the REST API service                                                                                                                          |
+| `teku_beacon_rest_api_host_allowlist`       | ["*"]                                                                                                                        | Host allowlist for for the REST API service                                                                                                                 |
+| `teku_cmdline_args`                         | []                                                                                                                           |                                                                                                                                                             |
+| `teku_env_opts`                             | []                                                                                                                           |                                                                                                                                                             |
+| `teku_env_opts_beacon`                      | `teku_env_opts`                                                                                                              | Only applicable in standalone mode. Allows setting beacon specific values                                                                                   |
+| `teku_env_opts_validator`                   | `teku_env_opts`                                                                                                              | Only applicable in standalone mode. Allows setting validator specific values                                                                                |
+| `teku_standalone_validator`                 | False                                                                                                                        | Run validator in standalone mode                                                                                                                            |
 
 
 List of variables which are not defined with default values in ansible role. However if these variables set via command line those will configured in teku configuration file
 
-| Name                                          | Configuration File Parameter             | Description |
-| --------------------------------------------- | ---------------------------------------- | ------------|
-| `teku_data_beacon_path`                       | `data-beacon-path`                       | Path to beacon data |
-| `teku_data_storage_archive_frequency`         | `data-storage-archive-frequency`         | Sets the frequency, in slots, at which to store finalized states to disk |
-| `teku_data_validator_path`                    | `data-validator-path`                    | Path to validator client data |
-| `teku_log_level`                              | `logging`                                | Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL |
-| `teku_log_validator_duties`                   | `log-include-validator-duties-enabled`   | Whether events are logged when validators perform duties |
-| `teku_p2p_discovery_bootnodes`                | `p2p-discovery-bootnodes`                | List of ENRs of the bootnodes ex: ['enr:-enr-string','enr:-enr-string'] |
-| `teku_p2p_peer_lower_bound`                   | `p2p-peer-lower-bound`                   | Lower bound on the target number of peers |
-| `teku_p2p_peer_upper_bound`                   | `p2p-peer-upper-bound`                   | Upper bound on the target number of peers |
-| `teku_p2p_static_peers`                       | `p2p-static-peers`                       | Static peers. ex: ['peer1-address','peer2-address'] |
-| `teku_p2p_subscribe_all_subnets_enabled`      | `p2p-subscribe-all-subnets-enabled`      | True/False |
-| `teku_validators_external_signer_public_keys` | `validators-external-signer-public-keys` | The list of external signer public keys ex: ['key1','key2'] |
-| `teku_validators_external_signer_timeout`     | `validators-external-signer-timeout`     | Timeout (in milliseconds) for the external signing  service |
-| `teku_validators_external_signer_url`         | `validators-external-signer-url`         | URL for the external signing service |
-| `teku_validators_graffiti`                    | `validators-graffiti`                    | Graffiti to include during block creation (gets converted to bytes and padded to Bytes32) |
-| `teku_validators_keystore_locking_enabled`    | `validators-keystore-locking-enabled`    | Enable locking validator keystore files (Valid values True, False) |
-| `teku_validators_performance_tracking_enabled`| `validators-performance-tracking-enabled`| Enable validator performance tracking and logging (Valid values True, False) |
-| `teku_ws_checkpoint`                          | `ws-checkpoint`                          | A recent checkpoint within the weak subjectivity period. Format <BLOCK_ROOT>:<EPOCH_NUMBER> |
+| Name                                             | Configuration File Parameter                | Description                                                                                 |
+|--------------------------------------------------|---------------------------------------------|---------------------------------------------------------------------------------------------|
+| `teku_data_beacon_path`                          | `data-beacon-path`                          | Path to beacon data                                                                         |
+| `teku_data_storage_archive_frequency`            | `data-storage-archive-frequency`            | Sets the frequency, in slots, at which to store finalized states to disk                    |
+| `teku_data_validator_path`                       | `data-validator-path`                       | Path to validator client data                                                               |
+| `teku_log_level`                                 | `logging`                                   | Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL                  |
+| `teku_log_validator_duties`                      | `log-include-validator-duties-enabled`      | Whether events are logged when validators perform duties                                    |
+| `teku_p2p_discovery_bootnodes`                   | `p2p-discovery-bootnodes`                   | List of ENRs of the bootnodes ex: ['enr:-enr-string','enr:-enr-string']                     |
+| `teku_p2p_peer_lower_bound`                      | `p2p-peer-lower-bound`                      | Lower bound on the target number of peers                                                   |
+| `teku_p2p_peer_upper_bound`                      | `p2p-peer-upper-bound`                      | Upper bound on the target number of peers                                                   |
+| `teku_p2p_static_peers`                          | `p2p-static-peers`                          | Static peers. ex: ['peer1-address','peer2-address']                                         |
+| `teku_p2p_subscribe_all_subnets_enabled`         | `p2p-subscribe-all-subnets-enabled`         | True/False                                                                                  |
+| `teku_validators_external_signer_public_keys`    | `validators-external-signer-public-keys`    | The list of external signer public keys ex: ['key1','key2']                                 |
+| `teku_validators_external_signer_timeout`        | `validators-external-signer-timeout`        | Timeout (in milliseconds) for the external signing  service                                 |
+| `teku_validators_external_signer_url`            | `validators-external-signer-url`            | URL for the external signing service                                                        |
+| `teku_validators-proposer-default-fee-recipient` | `validators-proposer-default-fee-recipient` | Default fee recipient to use when proposing post-merge blocks                               |
+| `teku_validators_graffiti`                       | `validators-graffiti`                       | Graffiti to include during block creation (gets converted to bytes and padded to Bytes32)   |
+| `teku_validators_keystore_locking_enabled`       | `validators-keystore-locking-enabled`       | Enable locking validator keystore files (Valid values True, False)                          |
+| `teku_validators_performance_tracking_enabled`   | `validators-performance-tracking-enabled`   | Enable validator performance tracking and logging (Valid values True, False)                |
+| `teku_ws_checkpoint`                             | `ws-checkpoint`                             | A recent checkpoint within the weak subjectivity period. Format <BLOCK_ROOT>:<EPOCH_NUMBER> |
 
 
 ### Standalone Mode

--- a/README.md
+++ b/README.md
@@ -88,26 +88,30 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 List of variables which are not defined with default values in ansible role. However if these variables set via command line those will configured in teku configuration file
 
-| Name                                             | Configuration File Parameter                | Description                                                                                 |
-|--------------------------------------------------|---------------------------------------------|---------------------------------------------------------------------------------------------|
-| `teku_data_beacon_path`                          | `data-beacon-path`                          | Path to beacon data                                                                         |
-| `teku_data_storage_archive_frequency`            | `data-storage-archive-frequency`            | Sets the frequency, in slots, at which to store finalized states to disk                    |
-| `teku_data_validator_path`                       | `data-validator-path`                       | Path to validator client data                                                               |
-| `teku_log_level`                                 | `logging`                                   | Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL                  |
-| `teku_log_validator_duties`                      | `log-include-validator-duties-enabled`      | Whether events are logged when validators perform duties                                    |
-| `teku_p2p_discovery_bootnodes`                   | `p2p-discovery-bootnodes`                   | List of ENRs of the bootnodes ex: ['enr:-enr-string','enr:-enr-string']                     |
-| `teku_p2p_peer_lower_bound`                      | `p2p-peer-lower-bound`                      | Lower bound on the target number of peers                                                   |
-| `teku_p2p_peer_upper_bound`                      | `p2p-peer-upper-bound`                      | Upper bound on the target number of peers                                                   |
-| `teku_p2p_static_peers`                          | `p2p-static-peers`                          | Static peers. ex: ['peer1-address','peer2-address']                                         |
-| `teku_p2p_subscribe_all_subnets_enabled`         | `p2p-subscribe-all-subnets-enabled`         | True/False                                                                                  |
-| `teku_validators_external_signer_public_keys`    | `validators-external-signer-public-keys`    | The list of external signer public keys ex: ['key1','key2']                                 |
-| `teku_validators_external_signer_timeout`        | `validators-external-signer-timeout`        | Timeout (in milliseconds) for the external signing  service                                 |
-| `teku_validators_external_signer_url`            | `validators-external-signer-url`            | URL for the external signing service                                                        |
-| `teku_validators-proposer-default-fee-recipient` | `validators-proposer-default-fee-recipient` | Default fee recipient to use when proposing post-merge blocks                               |
-| `teku_validators_graffiti`                       | `validators-graffiti`                       | Graffiti to include during block creation (gets converted to bytes and padded to Bytes32)   |
-| `teku_validators_keystore_locking_enabled`       | `validators-keystore-locking-enabled`       | Enable locking validator keystore files (Valid values True, False)                          |
-| `teku_validators_performance_tracking_enabled`   | `validators-performance-tracking-enabled`   | Enable validator performance tracking and logging (Valid values True, False)                |
-| `teku_ws_checkpoint`                             | `ws-checkpoint`                             | A recent checkpoint within the weak subjectivity period. Format <BLOCK_ROOT>:<EPOCH_NUMBER> |
+| Name                                              | Configuration File Parameter                 | Description                                                                                 |
+|---------------------------------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------|
+| `teku_data_beacon_path`                           | `data-beacon-path`                           | Path to beacon data                                                                         |
+| `teku_data_storage_archive_frequency`             | `data-storage-archive-frequency`             | Sets the frequency, in slots, at which to store finalized states to disk                    |
+| `teku_data_validator_path`                        | `data-validator-path`                        | Path to validator client data                                                               |
+| `teku_ee_endpoint`                                | `ee-endpoint`                                | The execution engine endpoint URL                                                           |
+| `teku_ee_jwt_secret_file`                         | `ee-jwt-secret-file`                         | File to read the execution engine JWT authentication secret from                            |
+| `teku_log_level`                                  | `logging`                                    | Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL                  |
+| `teku_log_validator_duties`                       | `log-include-validator-duties-enabled`       | Whether events are logged when validators perform duties                                    |
+| `teku_p2p_discovery_bootnodes`                    | `p2p-discovery-bootnodes`                    | List of ENRs of the bootnodes ex: ['enr:-enr-string','enr:-enr-string']                     |
+| `teku_p2p_peer_lower_bound`                       | `p2p-peer-lower-bound`                       | Lower bound on the target number of peers                                                   |
+| `teku_p2p_peer_upper_bound`                       | `p2p-peer-upper-bound`                       | Upper bound on the target number of peers                                                   |
+| `teku_p2p_static_peers`                           | `p2p-static-peers`                           | Static peers. ex: ['peer1-address','peer2-address']                                         |
+| `teku_p2p_subscribe_all_subnets_enabled`          | `p2p-subscribe-all-subnets-enabled`          | True/False                                                                                  |
+| `teku_validators_external_signer_public_keys`     | `validators-external-signer-public-keys`     | The list of external signer public keys ex: ['key1','key2']                                 |
+| `teku_validators_external_signer_timeout`         | `validators-external-signer-timeout`         | Timeout (in milliseconds) for the external signing  service                                 |
+| `teku_validators_external_signer_url`             | `validators-external-signer-url`             | URL for the external signing service                                                        |
+| `teku_validators_proposer_default_fee_recipient`  | `validators-proposer-default-fee-recipient`  | Default fee recipient to use when proposing post-merge blocks                               |
+| `teku_validators_proposer_config`                 | `validators-proposer-config`                 | Remote URL or local file path to load proposer configuration from                           |
+| `teku_validators_proposer_config_refresh_enabled` | `validators-proposer-config-refresh-enabled` | Whether to periodically refresh the proposer config                                         |
+| `teku_validators_graffiti`                        | `validators-graffiti`                        | Graffiti to include during block creation (gets converted to bytes and padded to Bytes32)   |
+| `teku_validators_keystore_locking_enabled`        | `validators-keystore-locking-enabled`        | Enable locking validator keystore files (Valid values True, False)                          |
+| `teku_validators_performance_tracking_enabled`    | `validators-performance-tracking-enabled`    | Enable validator performance tracking and logging (Valid values True, False)                |
+| `teku_ws_checkpoint`                              | `ws-checkpoint`                              | A recent checkpoint within the weak subjectivity period. Format <BLOCK_ROOT>:<EPOCH_NUMBER> |
 
 
 ### Standalone Mode

--- a/templates/teku.yml.j2
+++ b/templates/teku.yml.j2
@@ -50,16 +50,19 @@ Xinterop-enabled: {{teku_interop_enabled}}
 validators-key-file: "{{teku_validators_key_file}}"
 {% endif %}
 
-# deposit
+# Execution Layer
 {% if teku_deposit_contract_address != "0x" %}
 eth1-deposit-contract-address: "{{teku_deposit_contract_address}}"
 {% endif %}
 {% if teku_deposit_eth1_endpoint != "" %}
 eth1-endpoint: "{{teku_deposit_eth1_endpoint}}"
 {% endif %}
-
-# output
-#Xtransaction-record-directory: "/tmp/teku"
+{% if teku_ee_endpoint is defined and teku_ee_endpoint != "" %}
+ee-endpoint: "{{teku_ee_endpoint}}"
+{% endif %}
+{% if teku_ee_jwt_secret_file is defined and teku_ee_jwt_secret_file != "" %}
+ee-jwt-secret-file: "{{teku_ee_jwt_secret_file}}"
+{% endif %}
 
 # logging
 log-color-enabled: {{ teku_log_color_enabled }}
@@ -137,4 +140,16 @@ validators-key-password-files: [{{teku_validator_key_password_files|map('to_json
 
 {% if teku_validator_keys is defined and teku_validator_keys != [] %}
 validator-keys: [{{teku_validator_keys|map('to_json')|join(',')}}]
+{% endif %}
+
+{% if teku_validators_proposer_default_fee_recipient is defined and teku_validators_proposer_default_fee_recipient != "" %}
+validators-proposer-default-fee-recipient: "{{teku_validators_proposer_default_fee_recipient}}"
+{% endif %}
+
+{% if teku_validators_proposer_config is defined and teku_validators_proposer_config != "" %}
+validators-proposer-config: "{{teku_validators_proposer_config}}"
+{% endif %}
+
+{% if teku_validators_proposer_config_refresh_enabled is defined and teku_validators_proposer_config_refresh_enabled != "" %}
+validators-proposer-config-refresh-enabled: "{{teku_validators_proposer_config_refresh_enabled}}"
 {% endif %}


### PR DESCRIPTION
Add new merge options to teku role.

```
--ee-endpoint=<NETWORK>
                             URL for Execution Engine node.
      --ee-jwt-secret-file=<FILENAME>
                             Location of the file specifying the hex-encoded
                               256 bit secret key to be used for
                               verifying/generating jwt tokens
      --validators-proposer-default-fee-recipient[=<ADDRESS>]
                             Default fee recipient sent to the execution
                               engine, which could use it as fee recipient when
                               producing a new execution block.
      --validators-proposer-config[=<STRING>]
                             remote URL or local file path to load proposer
                               configuration from
      --validators-proposer-config-refresh-enabled[=<BOOLEAN>]
                             Enable the proposer configuration reload on every
                               proposer preparation (once per epoch)
                               Default: false
```

README diff is a bit of a mess because IntelliJ reformatted it to read well as text but seems worth it.