### PR TITLE
If teku_systemd_state == stopped ensure service is stopped and disabled

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -15,7 +15,7 @@
       systemd:
         name: "{{ teku_validator_service_name }}"
         state: stopped
-        enabled: no
+        enabled: false
       become: true
       when: "teku_standalone_validator_file_stat.stat.exists | bool"
 
@@ -63,8 +63,8 @@
     - name: Enable and start Teku service - monolith
       systemd:
         name: "{{ teku_monolith_service_name }}"
-        state: 'started'
-        enabled: true
+        state: "{{ teku_systemd_state }}"
+        enabled: "{{ false if teku_systemd_state == 'stopped' else true }}"
       become: true
       register: start_teku_monolith
       when:
@@ -173,8 +173,8 @@
     - name: Enable and start Teku service - beacon
       systemd:
         name: "{{ teku_beacon_service_name }}"
-        state: 'started'
-        enabled: true
+        state: "{{ teku_systemd_state }}"
+        enabled: "{{ false if teku_systemd_state == 'stopped' else true }}"
       become: true
       register: start_teku_standalone_beacon
       when:
@@ -195,8 +195,8 @@
     - name: Enable and start Teku service - validator
       systemd:
         name: "{{ teku_validator_service_name }}"
-        state: 'started'
-        enabled: true
+        state: "{{ teku_systemd_state }}"
+        enabled: "{{ false if teku_systemd_state == 'stopped' else true }}"
       become: true
       register: start_teku_standalone_validator
       when:


### PR DESCRIPTION
Currently, if you run with `teku_systemd_state: stopped` then it is ignored.

e.g. we "enable and start teku service", but skip "restart teku service"

```
TASK [consensys.teku : Enable and start Teku service - beacon] *****************
changed: [...]

TASK [consensys.teku : Restart Teku service - beacon] **************************
skipping: [...]
```

If you want to leave the service stopped after running the playbook, then likely you want the service disabled too otherwsie it will restart on boot.


Partially fixes https://github.com/Consensys/ansible-role-teku/issues/37