### PR TITLE
fix paths for download and untar

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,4 +279,3 @@ Consensys, 2025
 
 
 ### TODO
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.8.2
-ansible-lint==4.1.0
+ansible==10.7.0
+ansible-lint==4.3.0

--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -1,22 +1,22 @@
 ---
 
-- name: Ensure we have sane configuration
+- name: compile | Ensure we have sane configuration
   ansible.builtin.fail:
     msg: You must set "teku_git_repo" for this role to run when "teku_build_from_source" is enabled
   when: not (teku_git_repo is defined) or teku_git_repo|length == 0
 
-- name: Check JDK version
+- name: compile | Check JDK version
   shell: javac -version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+'
   register: jdk_version
   changed_when: false
   ignore_errors: true
 
-- name: Ensure JDK is installed
+- name: compile | Ensure JDK is installed
   ansible.builtin.fail:
     msg: "You must have JDK 21 or later installed. {{ 'No version found.' if jdk_version is failed else 'Found version ' + jdk_version.stdout }}"
   when: jdk_version.stdout is version('21.0.0', '<')
 
-- name: Clone Teku Sources
+- name: compile | Clone Teku Sources
   ansible.builtin.git:
     repo: "{{ teku_git_repo }}"
     dest: '/tmp/teku'
@@ -24,19 +24,20 @@
     recursive: false
     depth: 1
 
-- name: Build Teku
+- name: compile | Build Teku
   ansible.builtin.command: ./gradlew --no-daemon --parallel clean assemble
   args:
     chdir: /tmp/teku
   changed_when: true
 
-- name: Get Teku Version
+- name: compile | Get Teku Version
   ansible.builtin.shell: "basename build/distributions/*.tar.gz .tar.gz | sed 's/^teku-//'"
   args:
     chdir: /tmp/teku
   register: teku_version_cmd
   changed_when: false
 
-- name: Set Teku Version Fact
+- name: compile | Set Teku Facts
   ansible.builtin.set_fact:
     _teku_version: "{{ teku_version_cmd.stdout }}"
+    _teku_source_tarball: "/tmp/teku/build/distributions/teku-{{ teku_version_cmd.stdout }}.tar.gz"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,10 +104,20 @@
       become: true
   when: not ownership_marker.stat.exists
 
+- name: install | Set headers for GitHub download
+  set_fact:
+    _github_download_headers: >-
+      {{
+        {'Authorization': 'token ' + github_teku_token} 
+        if (github_teku_token is defined and github_teku_token | length > 0) 
+        else {}
+      }}
+
 - name: install | Download Teku binary for Teku version {{ _teku_version }} if not using teku_build_from_source
   ansible.builtin.get_url:
     url: "{{ teku_download_url }}"
     dest: "/tmp/teku-{{ teku_version }}.tar.gz"
+    headers: "{{ _github_download_headers }}"
     owner: "{{ teku_user }}"
     group: "{{ teku_group }}"
     mode: "0644"    

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,56 +104,128 @@
       become: true
   when: not ownership_marker.stat.exists
 
-- name: install | Set headers for GitHub download
+# Unarchive once if it’s a tarball
+# Unarchive twice if it’s an artifact ie a tar in a zip
+- name: install | Determine Teku download type
   set_fact:
-    _github_download_headers: >-
-      {{
-        {'Authorization': 'token ' + github_teku_token} 
-        if (github_teku_token is defined and github_teku_token | length > 0) 
-        else {}
-      }}
+    _teku_is_release: "{{ teku_download_url.endswith('.tar.gz') }}"
+    _teku_download_base: "/tmp/teku-{{ teku_version }}"
 
-- name: install | Download Teku binary for Teku version {{ _teku_version }} if not using teku_build_from_source
-  ansible.builtin.get_url:
-    url: "{{ teku_download_url }}"
-    dest: "/tmp/teku-{{ teku_version }}.tar.gz"
-    headers: "{{ _github_download_headers }}"
-    owner: "{{ teku_user }}"
-    group: "{{ teku_group }}"
-    mode: "0644"    
-  register: teku_binary_download
-  retries: 5
-  delay: 10
-  when: not teku_build_from_source
-  until: teku_binary_download is succeeded  
-  become: true
+# normal release
+- block:
+    - name: install | Download Teku release tarball
+      ansible.builtin.get_url:
+        url: "{{ teku_download_url }}"
+        dest: "{{ _teku_download_base }}.tar.gz"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+        mode: "0644"
+      register: teku_binary_download
+      retries: 5
+      delay: 10
+      until: teku_binary_download is succeeded
+      become: true
 
-- name: install | Extract Teku source to install directory
-  ansible.builtin.unarchive:
-    src: >-
-      {{ '/tmp/teku-' + teku_version + '.tar.gz'
-         if not teku_build_from_source
-         else '/tmp/teku/build/distributions/teku-' + teku_version + '.tar.gz' }}
-    remote_src: yes
-    dest: "{{ teku_install_dir }}"
-    owner: "{{ teku_user }}"
-    group: "{{ teku_group }}"
-    mode: "0775"
-    extra_opts:
-      - --strip-components
-      - "1"
-  become: true
-  register: extract_src
+    - name: install | Extract Teku release to install directory
+      ansible.builtin.unarchive:
+        src: "{{ _teku_download_base }}.tar.gz"
+        remote_src: yes
+        dest: "{{ teku_install_dir }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+        mode: "0775"
+        extra_opts:
+          - --strip-components=1
+      register: extract_src
+      become: true
 
-- name: install | Remove downloaded Teku archive after extraction
-  ansible.builtin.file:
-    path: "/tmp/teku-{{ teku_version }}.tar.gz"
-    state: absent
+    - name: install | Remove Teku release tarball
+      ansible.builtin.file:
+        path: "{{ _teku_download_base }}.tar.gz"
+        state: absent
+      become: true      
+
   when:
     - not teku_build_from_source
-    - extract_src is succeeded
-  become: true
+    - _teku_is_release
 
+# get from gha artifacts
+- block:
+    - name: install | Normalize Teku artifact API download URL
+      set_fact:
+        _teku_artifact_api_url: "https://api.github.com/repos/Consensys/teku/actions/artifacts/{{ teku_download_url | regex_search('artifacts/([0-9]+)', '\\1') | first }}/zip"
+
+    - name: install | Set headers for Teku artifact download
+      set_fact:
+        _github_download_headers:
+          Authorization: "Bearer {{ github_teku_token }}"
+          Accept: "application/vnd.github+json"
+
+    - name: install | Download Teku artifact zip
+      ansible.builtin.get_url:
+        url: "{{ _teku_artifact_api_url }}"
+        dest: "{{ _teku_download_base }}.zip"
+        headers: "{{ _github_download_headers }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+        mode: "0644"
+      register: teku_binary_download
+      retries: 5
+      delay: 10
+      until: teku_binary_download is succeeded
+      become: true
+
+    - name: install | Create temp dir for Teku artifact extraction
+      ansible.builtin.file:
+        path: "{{ _teku_download_base }}-artifact"
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: install | Extract Teku artifact zip
+      ansible.builtin.unarchive:
+        src: "{{ _teku_download_base }}.zip"
+        remote_src: yes
+        dest: "{{ _teku_download_base }}-artifact"
+      become: true
+
+    - name: install | Find Teku tarball inside artifact
+      ansible.builtin.find:
+        paths: "{{ _teku_download_base }}-artifact"
+        patterns: "*.tar.gz"
+        recurse: yes
+      register: _teku_artifact_tar
+
+    - name: install | Extract Teku tarball from artifact
+      ansible.builtin.unarchive:
+        src: "{{ _teku_artifact_tar.files[0].path }}"
+        remote_src: yes
+        dest: "{{ teku_install_dir }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+        mode: "0775"
+        extra_opts:
+          - --strip-components=1
+      register: extract_src
+      become: true
+
+    - name: install | Remove Teku artifact zip
+      ansible.builtin.file:
+        path: "{{ _teku_download_base }}.zip"
+        state: absent
+      become: true
+
+    - name: install | Cleanup Teku artifact temp dir
+      ansible.builtin.file:
+        path: "{{ _teku_download_base }}-artifact"
+        state: absent
+      become: true
+
+  when:
+    - not teku_build_from_source
+    - not _teku_is_release
+
+## Now that we have the installation done from all these various places
 - name: install | Create a symlink to current
   ansible.builtin.file:
     src: "{{ teku_install_dir }}/"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -155,24 +155,20 @@
       set_fact:
         _teku_artifact_api_url: "https://api.github.com/repos/Consensys/teku/actions/artifacts/{{ teku_download_url | regex_search('artifacts/([0-9]+)', '\\1') | first }}/zip"
 
-    - name: install | Set headers for Teku artifact download
-      set_fact:
-        _github_download_headers:
-          Authorization: "Bearer {{ github_teku_token }}"
-          Accept: "application/vnd.github+json"
-
-    - name: install | Download Teku artifact zip
-      ansible.builtin.get_url:
-        url: "{{ _teku_artifact_api_url }}"
-        dest: "{{ _teku_download_base }}.zip"
-        headers: "{{ _github_download_headers }}"
-        owner: "{{ teku_user }}"
-        group: "{{ teku_group }}"
-        mode: "0644"
-      register: teku_binary_download
+    # dont use get_url or uri - getting this off azure blob storage is super painful
+    - name: install | Download Teku artifact zip (curl)
+      ansible.builtin.command: >
+        curl -L
+        -H "Authorization: Bearer {{ github_teku_token }}"
+        -H "Accept: application/vnd.github+json"
+        -H "User-Agent: ansible-teku-installer"
+        -o {{ _teku_download_base }}.zip
+        {{ _teku_artifact_api_url }}
+      register: curl_result
       retries: 5
       delay: 10
-      until: teku_binary_download is succeeded
+      until: curl_result.rc == 0
+      changed_when: true
       become: true
 
     - name: install | Create temp dir for Teku artifact extraction

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,21 +104,26 @@
       become: true
   when: not ownership_marker.stat.exists
 
-- name: install | Download Teku binary for Teku version {{ _teku_version }}
+- name: install | Download Teku binary for Teku version {{ _teku_version }} if not using teku_build_from_source
   ansible.builtin.get_url:
     url: "{{ teku_download_url }}"
-    dest: "{{ teku_base_dir }}"
+    dest: "/tmp/teku-{{ teku_version }}.tar.gz"
     owner: "{{ teku_user }}"
     group: "{{ teku_group }}"
+    mode: "0644"    
   register: teku_binary_download
   retries: 5
   delay: 10
+  when: not teku_build_from_source
   until: teku_binary_download is succeeded  
   become: true
 
 - name: install | Extract Teku source to install directory
   ansible.builtin.unarchive:
-    src: "{{ '/tmp/teku/build/distributions/teku-' + teku_version + '.tar.gz' if teku_build_from_source else teku_download_url }}"
+    src: >-
+      {{ '/tmp/teku-' + teku_version + '.tar.gz'
+         if not teku_build_from_source
+         else '/tmp/teku/build/distributions/teku-' + teku_version + '.tar.gz' }}
     remote_src: yes
     dest: "{{ teku_install_dir }}"
     owner: "{{ teku_user }}"
@@ -129,6 +134,15 @@
       - "1"
   become: true
   register: extract_src
+
+- name: install | Remove downloaded Teku archive after extraction
+  ansible.builtin.file:
+    path: "/tmp/teku-{{ teku_version }}.tar.gz"
+    state: absent
+  when:
+    - not teku_build_from_source
+    - extract_src is succeeded
+  become: true
 
 - name: install | Create a symlink to current
   ansible.builtin.file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -57,7 +57,7 @@
     - teku-validator.service
     - teku.service
   register: teku_systemd_stopped
-  when: (ansible_facts.services[item] is defined) and 
+  when: (ansible_facts.services[item] is defined) and
         (ansible_facts.services[item].status == 'enabled')
 
 - name: install | Set updated optionally to trigger a systemd restart at the end - teku_beacon_state_updates
@@ -82,7 +82,7 @@
   when: (item.item == 'teku.service') and
         (item is defined) and
         (item.state | default('') == "stopped")
-  loop: "{{ teku_systemd_stopped.results }}"      
+  loop: "{{ teku_systemd_stopped.results }}"
 
 - block:
     - name: install | One-time recursive ownership of data dir
@@ -108,10 +108,9 @@
 # Unarchive twice if it’s an artifact ie a tar in a zip
 - name: install | Determine Teku download type
   set_fact:
-    _teku_is_release: "{{ teku_download_url.endswith('.tar.gz') }}"
-    _teku_download_base: "/tmp/teku-{{ teku_version }}"
+    _teku_download_base: "/tmp/teku-{{ _teku_version }}"
 
-# normal release
+# case 1 - normal case - release
 - block:
     - name: install | Download Teku release tarball
       ansible.builtin.get_url:
@@ -143,13 +142,13 @@
       ansible.builtin.file:
         path: "{{ _teku_download_base }}.tar.gz"
         state: absent
-      become: true      
+      become: true
 
   when:
     - not teku_build_from_source
-    - _teku_is_release
+    - teku_download_url.endswith('.tar.gz')
 
-# get from gha artifacts
+# case 2 - get from gha artifacts
 - block:
     - name: install | Normalize Teku artifact API download URL
       set_fact:
@@ -219,7 +218,31 @@
 
   when:
     - not teku_build_from_source
-    - not _teku_is_release
+    - not teku_download_url.endswith('.tar.gz')
+
+
+# case 3 - install from the local build
+- block:
+    - name: install | Extract Teku (built from source)
+      ansible.builtin.unarchive:
+        src: "{{ _teku_source_tarball }}"
+        remote_src: true
+        dest: "{{ teku_install_dir }}"
+        owner: "{{ teku_user }}"
+        group: "{{ teku_group }}"
+        mode: "0775"
+        extra_opts:
+          - --strip-components=1
+      register: extract_src
+      become: true
+
+    - name: install | Cleanup Teku source tarball
+      ansible.builtin.file:
+        path: "{{ _teku_source_tarball }}"
+        state: absent
+      become: true
+
+  when: teku_build_from_source
 
 ## Now that we have the installation done from all these various places
 - name: install | Create a symlink to current

--- a/tasks/tags.yml
+++ b/tasks/tags.yml
@@ -1,4 +1,4 @@
-- name: tags | Set the version on a local file so it can be used by other automation
+- name: tags | Set the version on a local file so it can be used by other automation # noqa E602
   ansible.builtin.copy:
     content: "{{ _teku_version }}"
     dest: "{{ teku_version_info_file }}"
@@ -6,9 +6,10 @@
     group: "{{ teku_group }}"
     mode: 0644
   become: true
-  when: teku_ee_endpoint is defined and teku_ee_endpoint != ""
-  when: (teku_beacon_enabled) or
-        (teku_combined_enabled and (teku_ee_endpoint is defined and teku_ee_endpoint != ""))
+  when: >
+    teku_beacon_enabled or
+    (teku_combined_enabled and
+    (teku_ee_endpoint | default('') | length > 0))
 
 - name: tags | Set the teku validator version on a local file so it can be used by other automation
   ansible.builtin.copy:


### PR DESCRIPTION
- download paths appeared to be downloading the thing 2x 
- now we download once, unarchive once as the next step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix installer download/extract logic; add artifact support; update tooling**
> 
> - **Refactors `tasks/install.yml`:** replaces prior double-download/untar with a clear 3‑path flow:
>   - *Release tarballs (`.tar.gz`)*: download once to `/_teku_download_base.tar.gz` and unarchive with `--strip-components=1`, then clean up.
>   - *GitHub Actions artifacts (`…/artifacts/{id}`)*: build API URL, download a zip via `curl`, extract to temp dir, find inner `*.tar.gz`, unarchive once to `teku_install_dir`, and clean up.
>   - *Local source build*: unarchive `/_teku_source_tarball` produced by compile step and remove it.
>   - Introduces `set_fact` for `_teku_download_base` and uses registered `extract_src` to gate systemd restarts. Minor whitespace/loop `when` cleanup.
> 
> - **Compile role tweaks:** prefix task names with `compile |`; set `_teku_source_tarball` alongside `_t e k u _ v e r s i o n` for later install use.
> 
> - **Tags role:** consolidates conditional logic with safer defaults and adds `# noqa E602`.
> 
> - **Tooling:** bumps `ansible` to `10.7.0` and `ansible-lint` to `4.3.0` in `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac496cd5df0088903732b7719c46a722a7d4386. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->