### PR TITLE
fix(install): stop racing live teku writers when chowning data dir

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,12 +67,26 @@
     state: directory
     owner: "{{ teku_user }}"
     group: "{{ teku_group }}"
-    recurse: true    
+    recurse: true
   loop:
     - "{{ teku_base_dir }}"
     - "{{ teku_install_dir }}"
     - "{{ teku_config_dir }}"
     - "{{ teku_log_dir }}"
+  become: true
+
+# Data dirs are owned by a running Teku process: a recursive walk here
+# races RocksDB compaction (*.ldb) and slashprotection atomic writes (*.tmp)
+# and fails with ENOENT. Top-level ensure only; the gated one-time block
+# below handles recursive ownership after services are stopped.
+- name: install | Ensure data directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ teku_user }}"
+    group: "{{ teku_group }}"
+    recurse: false
+  loop:
     - "{{ teku_data_dir }}"
     - "{{ teku_validator_data_dir }}"
   become: true


### PR DESCRIPTION
## Summary

`install | Create directories` (tasks/install.yml:64) ran `ansible.builtin.file` with `recurse: true` over a loop that included `teku_data_dir` and `teku_validator_data_dir`. On an upgrade where `teku-beacon` / `teku-validator` are still running, the recursive walk races two live writers and fails with ENOENT:

- RocksDB compaction unlinks `*.ldb` sstables under `<data>/beacon/db/`
- Slashing-protection atomic writes rename out `*.yml.tmp` under `<data>/validator/slashprotection/`

Observed in production (Jenkins `Besu/elc-update-Hoodi` build #57 on `prd-elc-bu-tk-hoodi-validator-03`):

```
TASK [consensys.teku : install | Create directories]
[ERROR]: [Errno 2] No such file or directory: '/data/teku/beacon/db/16760164.ldb'
[ERROR]: [Errno 2] No such file or directory: '/data/teku/beacon/db/16760179.ldb'
failed: [10.0.24.68] (item=/data/teku)
```

This is intermittent — same playbook run on a sibling host (validator-02) passed in the same window. The race is timing-dependent, so it can mask itself across many runs and then bite during a release deploy.

## Fix

The role already has a marker-gated one-time recursive ownership block at lines 137-155 that runs *after* the systemd stop step, so a deep chown of the data dir on every run is unnecessary and unsafe. Split the loop:

- install / config / log dirs keep `recurse: true` (no concurrent writer)
- data dirs get top-level ensure only (`recurse: false`)

First-run deep ownership is still handled by the existing gated block; on subsequent runs the data dirs already exist and we no longer touch their contents while teku is live.

Diff is +15 / -1.

## Test plan

- [ ] Fresh install (no `.ownership_initialized` marker): data dirs get created and recursively chowned by the existing one-time block after services stop.
- [ ] Upgrade against a host with teku-beacon + teku-validator running and the marker present: `install | Create directories` and `install | Ensure data directories exist` both succeed without touching live `*.ldb` / `*.yml.tmp` files.
- [ ] Upgrade against a host with services stopped: behavior unchanged (data dirs already owned correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small Ansible task change limited to directory creation/ownership, primarily reducing intermittent upgrade failures; main risk is missing recursive ownership if the one-time ownership block is skipped.
> 
> **Overview**
> Prevents intermittent upgrade failures by **splitting directory creation** in `tasks/install.yml`: install/config/log dirs still use `recurse: true`, while `teku_data_dir` and `teku_validator_data_dir` are now only ensured at the top level with `recurse: false` to avoid racing live Teku writers.
> 
> Adds inline documentation explaining the ENOENT race and relies on the existing marker-gated, post-stop one-time recursive ownership block for initial deep ownership initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43a2ab88575e67a387e8839f866256cbdb228b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->